### PR TITLE
compatibility with GHC 9.4.8 (#74)

### DIFF
--- a/src/Language/Hasmtlib/Codec.hs
+++ b/src/Language/Hasmtlib/Codec.hs
@@ -5,7 +5,9 @@
 
 module Language.Hasmtlib.Codec where
 
-import Prelude hiding (not, (&&), (||), all, and)
+import Prelude hiding (Applicative(..), not, (&&), (||), all, and)
+import Control.Applicative(Applicative(..))
+
 import Language.Hasmtlib.Internal.Bitvec
 import Language.Hasmtlib.Internal.Expr
 import Language.Hasmtlib.Type.Solution

--- a/src/Language/Hasmtlib/Iteable.hs
+++ b/src/Language/Hasmtlib/Iteable.hs
@@ -2,6 +2,9 @@
 
 module Language.Hasmtlib.Iteable where
 
+import Prelude hiding (Applicative(..))
+import Control.Applicative (Applicative(..))
+
 import Language.Hasmtlib.Internal.Expr
 import Language.Hasmtlib.Type.SMTSort
 import Data.Sequence (Seq)

--- a/src/Language/Hasmtlib/Variable.hs
+++ b/src/Language/Hasmtlib/Variable.hs
@@ -2,6 +2,9 @@
 
 module Language.Hasmtlib.Variable where
 
+import Prelude hiding (Applicative(..))
+import Control.Applicative (Applicative(..))
+
 import Language.Hasmtlib.Internal.Expr
 import Language.Hasmtlib.Type.MonadSMT
 import Language.Hasmtlib.Type.SMTSort


### PR DESCRIPTION
Explicitly import `Control.Applicative(Applicative(..))` since `liftA2` is not exported from Prelude in base 4.17.2.